### PR TITLE
Use cross-platform compatible paths

### DIFF
--- a/eventhandling.py
+++ b/eventhandling.py
@@ -89,7 +89,7 @@ def bioscan_event(cmdr: str, is_beta, entry, plugin, currententrytowrite) -> Non
                 # we have to save the data here.
                 logger.debug("Saving data to notsoldbiodata.json")
                 plugin.notyetsolddata[cmdr].append(currententrytowrite.copy())
-                file = plugin.AST_DIR + "\\notsoldbiodata.json"
+                file = plugin.AST_DIR + "/notsoldbiodata.json"
                 with open(file, "r+", encoding="utf8") as f:
                     notsolddata = json.load(f)
                     if cmdr not in notsolddata.keys():
@@ -326,7 +326,7 @@ def biosell_event(cmdr: str, entry, plugin) -> None:
                     continue
             i += 1
 
-        f = open(plugin.AST_DIR + "\\notsoldbiodata.json", "r+", encoding="utf8")
+        f = open(plugin.AST_DIR + "/notsoldbiodata.json", "r+", encoding="utf8")
         scanneddata = json.load(f)
         scanneddata[cmdr] = []
         f.seek(0)
@@ -335,7 +335,7 @@ def biosell_event(cmdr: str, entry, plugin) -> None:
         f.close()
 
         if plugin.notyetsolddata[cmdr] != []:
-            file = plugin.AST_DIR + "\\notsoldbiodata.json"
+            file = plugin.AST_DIR + "/notsoldbiodata.json"
             with open(file, "r+", encoding="utf8") as f:
                 notsolddata = json.load(f)
                 for data in plugin.notyetsolddata[cmdr]:
@@ -368,7 +368,7 @@ def biosell_event(cmdr: str, entry, plugin) -> None:
         logger.info('Set Unsold Scan Value to 0 Cr')
         plugin.AST_value.set("0 Cr.")
         plugin.rawvalue = 0
-        f = open(plugin.AST_DIR + "\\notsoldbiodata.json", "r+", encoding="utf8")
+        f = open(plugin.AST_DIR + "/notsoldbiodata.json", "r+", encoding="utf8")
         scanneddata = json.load(f)
         scanneddata[cmdr] = []
         f.seek(0)
@@ -397,7 +397,7 @@ def biosell_event(cmdr: str, entry, plugin) -> None:
         plugin.AST_value.set("0 Cr.")
         plugin.rawvalue = 0
     # Now write the data into the local file
-    file = plugin.AST_DIR + "\\soldbiodata.json"
+    file = plugin.AST_DIR + "/soldbiodata.json"
     with open(file, "r+", encoding="utf8") as f:
         solddata = json.load(f)
 

--- a/journalcrawler.py
+++ b/journalcrawler.py
@@ -94,12 +94,12 @@ def build_biodata_json(logger: any, journaldir: str) -> int:
     sold_exobiology = {}
     possibly_sold_data = {}
 
-    if not os.path.exists(directory + "\\soldbiodata.json"):
-        f = open(directory + "\\soldbiodata.json", "w", encoding="utf8")
+    if not os.path.exists(directory + "/soldbiodata.json"):
+        f = open(directory + "/soldbiodata.json", "w", encoding="utf8")
         f.write(r"{}")
         f.close()
 
-    with open(directory + "\\soldbiodata.json", "r", encoding="utf8") as f:
+    with open(directory + "/soldbiodata.json", "r", encoding="utf8") as f:
         sold_exobiology = json.load(f)
         # logger.debug(sold_exobiology)
         # logger.debug(len(sold_exobiology))
@@ -347,7 +347,7 @@ def build_biodata_json(logger: any, journaldir: str) -> int:
 
     solddata = None
 
-    with open(directory + "\\soldbiodata.json", "r+", encoding="utf8") as f:
+    with open(directory + "/soldbiodata.json", "r+", encoding="utf8") as f:
         solddata = json.load(f)
 
         for currentcmdr in totalcmdrlist:
@@ -374,7 +374,7 @@ def build_biodata_json(logger: any, journaldir: str) -> int:
 
     notsolddata = None
 
-    with open(directory + "\\notsoldbiodata.json", "r+", encoding="utf8") as f:
+    with open(directory + "/notsoldbiodata.json", "r+", encoding="utf8") as f:
         notsolddata = json.load(f)
         for currentcmdr in totalcmdrlist:
             if currentcmdr not in notsolddata.keys():
@@ -426,7 +426,7 @@ class loggingthing:
 if __name__ == "__main__":
     logger = loggingthing()
     directory, sourcename = os.path.split(os.path.realpath(__file__))
-    journaldir = directory + "\\journals\\"
+    journaldir = directory + "/journals/"
     build_biodata_json(logger, journaldir)
     journaldir = "<Path>"
     build_biodata_json(logger, journaldir)

--- a/load.py
+++ b/load.py
@@ -40,7 +40,7 @@ plugin = None
 # tracking of all the biological things that the CMDR scans.
 directory, filename = os.path.split(os.path.realpath(__file__))
 
-filenames = ["\\soldbiodata.json", "\\notsoldbiodata.json",  "\\cmdrstates.json"]
+filenames = ["/soldbiodata.json", "/notsoldbiodata.json",  "/cmdrstates.json"]
 
 
 for file in filenames:
@@ -48,7 +48,7 @@ for file in filenames:
         f = open(directory + file, "w", encoding="utf8")
         f.write(r"{}")
         f.close()
-    elif file == "\\soldbiodata.json" or file == "\\notsoldbiodata.json":
+    elif file == "/soldbiodata.json" or file == "/notsoldbiodata.json":
         # (not)soldbiodata file already exists
         with open(directory + file, "r+", encoding="utf8") as f:
             test = json.load(f)
@@ -64,10 +64,10 @@ for file in filenames:
 
 # load notyetsolddata and cmdrstates
 
-with open(directory + "\\notsoldbiodata.json", "r+", encoding="utf8") as f:
+with open(directory + "/notsoldbiodata.json", "r+", encoding="utf8") as f:
     not_yet_sold_data = json.load(f)
 
-with open(directory + "\\cmdrstates.json", "r+", encoding="utf8") as f:
+with open(directory + "/cmdrstates.json", "r+", encoding="utf8") as f:
     cmdrstates = json.load(f)
 
 

--- a/saving.py
+++ b/saving.py
@@ -16,7 +16,7 @@ def save_cmdr(cmdr, plugin) -> None:
     for i in range(len(plugin.CMDR_states[cmdr])):
         plugin.CMDR_states[cmdr][i] = valuelist[i]
 
-    file = plugin.AST_DIR + "\\cmdrstates.json"
+    file = plugin.AST_DIR + "/cmdrstates.json"
 
     open(file, "r+", encoding="utf8").close()
     with open(file, "r+", encoding="utf8") as f:
@@ -28,7 +28,7 @@ def save_cmdr(cmdr, plugin) -> None:
 def load_cmdr(cmdr, plugin) -> None:
     """Load information about a cmdr from cmdrstates.json."""
 
-    file = plugin.AST_DIR + "\\cmdrstates.json"
+    file = plugin.AST_DIR + "/cmdrstates.json"
 
     with open(file, "r+", encoding="utf8") as f:
         plugin.CMDR_states = json.load(f)

--- a/ui.py
+++ b/ui.py
@@ -168,11 +168,11 @@ def build_sold_bio_ui(plugin, cmdr: str, current_row) -> None:
     soldbiodata = {}
     notsoldbiodata = {}
 
-    file = plugin.AST_DIR + "\\soldbiodata.json"
+    file = plugin.AST_DIR + "/soldbiodata.json"
     with open(file, "r+", encoding="utf8") as f:
         soldbiodata = json.load(f)
 
-    file = plugin.AST_DIR + "\\notsoldbiodata.json"
+    file = plugin.AST_DIR + "/notsoldbiodata.json"
     with open(file, "r+", encoding="utf8") as f:
         notsoldbiodata = json.load(f)
 


### PR DESCRIPTION
Artemis uses a number of backslash-delimited paths which only work on Windows.

As far as I can tell, the plugin works fine otherwise on Linux. Forward slashes should work fine for both platforms.